### PR TITLE
ac-003: Add theme toggle component with cookie persistence

### DIFF
--- a/THEME_IMPLEMENTATION.md
+++ b/THEME_IMPLEMENTATION.md
@@ -1,0 +1,98 @@
+# Theme Toggle Implementation with Cookie Persistence
+
+## Overview
+A complete theme toggle system with light/dark mode support, cookie-based persistence, and SSR-safe rendering to prevent FOUC (Flash of Unstyled Content).
+
+## Files Created/Modified
+
+### 1. **src/lib/theme.svelte.ts**
+- Svelte store for managing theme state
+- `theme` store with subscribe/set methods
+- `applyTheme()` function to update HTML element, localStorage, and store
+- `getCurrentTheme()` function to read theme from DOM (SSR-safe)
+- Type-safe with `Theme = 'light' | 'dark'`
+
+### 2. **src/lib/ThemeToggle.svelte**
+- Interactive toggle component with rotating sun/moon icons
+- Uses `.swap` and `.swap-rotate` CSS classes for animation
+- Immediately updates client-side state
+- Syncs with server via fetch to `/theme` API endpoint
+- Respects SSR by waiting for client hydration
+
+### 3. **src/hooks.server.ts**
+- SvelteKit Handle hook for server-side theme detection
+- Reads theme from cookie and injects it into HTML element via `transformPageChunk`
+- Prevents theme flash on page load by setting data-theme before rendering
+- Cookie-based persistence across requests
+
+### 4. **src/routes/+layout.server.ts**
+- `load()` function to pass theme from cookie to layout
+- Provides server-side theme data to layout component
+
+### 5. **src/routes/+layout.svelte**
+- Imports and displays ThemeToggle component in header
+- Syncs server-provided theme with client on mount
+- Maintains header styling for light/dark modes
+
+### 6. **src/routes/theme/+server.ts**
+- POST endpoint at `/theme` for setting theme cookie
+- Validates theme value (must be 'light' or 'dark')
+- Sets HTTP cookie with 1-year expiration
+- Returns JSON response with theme value
+
+### 7. **src/app.html**
+- Added `data-theme="light"` attribute to `<html>` element
+- Default theme to prevent errors on first load
+- Dynamically replaced by hooks.server.ts with actual theme
+
+## Key Features
+
+✅ **SSR-Safe**: No flash of wrong theme - theme applied server-side before rendering
+✅ **Persistent**: Cookie-based persistence across sessions (1-year expiration)
+✅ **Responsive**: Instant client-side updates with smooth animations
+✅ **Typed**: Full TypeScript support with Theme type
+✅ **Accessible**: Proper ARIA labels for toggle checkbox
+✅ **Styled**: Custom CSS for swap/rotate animation effects
+✅ **API-Based**: Clean separation of concerns with dedicated theme endpoint
+
+## How It Works
+
+1. **Initial Page Load**:
+   - Server reads theme from cookie (or defaults to 'light')
+   - hooks.server.ts injects theme into HTML data-theme attribute
+   - Page renders with correct theme immediately
+
+2. **Client Hydration**:
+   - ThemeToggle component reads current theme from HTML element
+   - Subscribes to theme store for updates
+   - Checkbox is disabled until hydration complete
+
+3. **Theme Toggle**:
+   - User clicks toggle
+   - `applyTheme()` immediately updates:
+     - HTML data-theme attribute
+     - localStorage (client-side fallback)
+     - Svelte store (reactive updates)
+   - Component sends POST to `/theme` API endpoint
+   - Server updates cookie for future sessions
+
+## Usage
+
+The ThemeToggle component is already imported and rendered in the layout header. Users can click the sun/moon icon to toggle between light and dark themes.
+
+## Customization
+
+- **Change default theme**: Edit `hooks.server.ts` line where it defaults to 'light'
+- **Change theme names**: Update `Theme` type in `theme.svelte.ts` and update validation in `theme/+server.ts`
+- **Change styling**: Modify `.swap` and `.swap-rotate` classes in ThemeToggle.svelte
+- **Change cookie expiration**: Modify `maxAge` in `theme/+server.ts`
+- **Add system preference detection**: Use `window.matchMedia('(prefers-color-scheme: dark)')` in ThemeToggle component
+
+## Browser Support
+
+Works in all modern browsers with:
+- ES2020+ support
+- Svelte 5.x
+- SvelteKit 2.x
+- Cookie support
+

--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,20 @@
+import type { Handle } from '@sveltejs/kit';
+
+export const handle: Handle = async ({ event, resolve }) => {
+	// Get theme from cookies
+	const theme = event.cookies.get('theme') || 'light';
+
+	// Pass theme to the page via data attribute
+	const response = await resolve(event, {
+		transformPageChunk: ({ html }) => {
+			// Inject the theme data attribute into the HTML element
+			// This prevents flash of wrong theme
+			return html.replace(
+				'<html lang="en"',
+				`<html lang="en" data-theme="${theme}"`
+			);
+		},
+	});
+
+	return response;
+};

--- a/src/lib/ThemeToggle.svelte
+++ b/src/lib/ThemeToggle.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+	import { theme, applyTheme, getCurrentTheme } from './theme.svelte';
+	import { onMount } from 'svelte';
+
+	let currentTheme = $state<'light' | 'dark'>('light');
+	let isClient = $state(false);
+
+	onMount(() => {
+		isClient = true;
+		// Set initial theme from HTML element
+		currentTheme = getCurrentTheme();
+		// Subscribe to theme changes
+		const unsubscribe = theme.subscribe((t) => {
+			currentTheme = t;
+		});
+		return unsubscribe;
+	});
+
+	function handleToggle() {
+		const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+		applyTheme(newTheme);
+
+		// Sync with server via API (fire and forget)
+		fetch('/theme', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ theme: newTheme }),
+		}).catch(() => {
+			// Silently fail - theme is already updated on client
+		});
+	}
+</script>
+
+<!-- Swap component similar to daisyUI toggle but customizable -->
+<label class="swap swap-rotate">
+	<!-- This hidden checkbox controls the state -->
+	<input
+		type="checkbox"
+		checked={currentTheme === 'dark'}
+		onchange={handleToggle}
+		disabled={!isClient}
+		aria-label="Toggle dark mode"
+	/>
+
+	<!-- Sun icon (light mode) -->
+	<svg
+		class="swap-off h-5 w-5 fill-current"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+	>
+		<path
+			d="M5.64,4.59e-07C5.11,0.89 4.8,1.95 4.8,3.09C4.8,6.81 7.66,9.9 11.25,9.9C12.39,9.9 13.45,9.59 14.34,9.05L13.41,8.12C12.78,8.4 12.09,8.59 11.35,8.59C8.41,8.59 6.09,6.27 6.09,3.32C6.09,2.58 6.28,1.89 6.56,1.26L5.64,4.59e-07M19.78,4.45L18.29,2.96C17.68,3.62 17.26,4.41 17.08,5.28C16.41,5.08 15.69,4.97 14.95,4.97C12.8,4.97 10.95,6.02 9.91,7.57L8.5,6.16C9.66,4.88 11.25,4.04 13.05,3.71C13.29,2.93 13.77,2.25 14.4,1.75L12.92,0.26C11.97,1.16 11.25,2.37 11.01,3.74C9.5,3.87 8.15,4.65 7.35,5.84L5.94,4.43C7.35,2.92 9.3,2 11.5,2C12.3,2 13.08,2.1 13.84,2.27C14.17,1.33 14.84,0.55 15.7,0.05L17.19,1.54C16.83,1.87 16.54,2.27 16.36,2.73C17.42,2.95 18.36,3.54 19.04,4.31L19.78,4.45M11.5,7C10.12,7 9,8.12 9,9.5C9,10.88 10.12,12 11.5,12C12.88,12 14,10.88 14,9.5C14,8.12 12.88,7 11.5,7Z"
+		/>
+	</svg>
+
+	<!-- Moon icon (dark mode) -->
+	<svg
+		class="swap-on h-5 w-5 fill-current"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+	>
+		<path
+			d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
+		/>
+	</svg>
+</label>
+
+<style>
+	.swap {
+		position: relative;
+		display: inline-block;
+		width: auto;
+		height: auto;
+	}
+
+	.swap input {
+		display: none;
+	}
+
+	.swap.swap-rotate input:checked ~ .swap-on,
+	.swap.swap-rotate input:not(:checked) ~ .swap-off {
+		display: block;
+	}
+
+	.swap.swap-rotate input:checked ~ .swap-off,
+	.swap.swap-rotate input:not(:checked) ~ .swap-on {
+		display: none;
+	}
+
+	.swap svg {
+		transition: all 0.3s ease-in-out;
+	}
+
+	.swap.swap-rotate input:checked ~ svg {
+		transform: rotate(180deg);
+	}
+
+	.swap input:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	.swap input:not(:disabled) {
+		cursor: pointer;
+	}
+</style>

--- a/src/lib/theme.svelte.ts
+++ b/src/lib/theme.svelte.ts
@@ -1,0 +1,57 @@
+import { browser } from '$app/environment';
+import { writable } from 'svelte/store';
+
+export type Theme = 'light' | 'dark';
+
+// Initialize store with default theme
+function createThemeStore() {
+	// Server-side: start with 'light' as default
+	// Client-side: will be hydrated from SSR
+	let initialTheme: Theme = 'light';
+
+	// If we're in the browser and localStorage is available, use it as fallback
+	// The actual theme comes from HTML data-theme attribute (set by server)
+	if (browser && localStorage) {
+		const stored = localStorage.getItem('theme') as Theme | null;
+		if (stored === 'light' || stored === 'dark') {
+			initialTheme = stored;
+		}
+	}
+
+	const { subscribe, set } = writable<Theme>(initialTheme);
+
+	return {
+		subscribe,
+		set,
+		toggle: () => {
+			let newTheme: Theme;
+			subscribe((current) => {
+				newTheme = current === 'light' ? 'dark' : 'light';
+				return current;
+			})();
+			set(newTheme!);
+		},
+	};
+}
+
+export const theme = createThemeStore();
+
+// Function to update the HTML element's data-theme
+export function applyTheme(newTheme: Theme) {
+	if (browser) {
+		document.documentElement.setAttribute('data-theme', newTheme);
+		localStorage.setItem('theme', newTheme);
+		theme.set(newTheme);
+	}
+}
+
+// Function to get current theme from HTML element (SSR-safe)
+export function getCurrentTheme(): Theme {
+	if (browser) {
+		const dataTheme = document.documentElement.getAttribute('data-theme');
+		if (dataTheme === 'light' || dataTheme === 'dark') {
+			return dataTheme;
+		}
+	}
+	return 'light';
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,6 @@
+import type { RequestEvent } from '@sveltejs/kit';
+
+export async function load({ cookies }: RequestEvent) {
+	const theme = cookies.get('theme') || 'light';
+	return { theme };
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,9 +1,26 @@
 <script lang="ts">
 	import './layout.css';
 	import favicon from '$lib/assets/favicon.svg';
+	import ThemeToggle from '$lib/ThemeToggle.svelte';
+	import { applyTheme } from '$lib/theme.svelte';
+	import type { PageData } from './$types';
+	import { onMount } from 'svelte';
 
-	let { children } = $props();
+	let { children, data }: { children: any; data: PageData } = $props();
+
+	// Sync server theme with client on mount
+	onMount(() => {
+		if (data?.theme) {
+			applyTheme(data.theme as 'light' | 'dark');
+		}
+	});
 </script>
 
 <svelte:head><link rel="icon" href={favicon} /></svelte:head>
+
+<header class="flex items-center justify-between border-b border-base-300 bg-base-100 px-4 py-3">
+	<h1 class="text-xl font-bold">App</h1>
+	<ThemeToggle />
+</header>
+
 {@render children()}

--- a/src/routes/theme/+server.ts
+++ b/src/routes/theme/+server.ts
@@ -1,0 +1,22 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler, RequestEvent } from '@sveltejs/kit';
+
+export const POST: RequestHandler = async (event: RequestEvent) => {
+	const { request, cookies } = event;
+	const data = await request.json();
+	const theme = data.theme as string;
+
+	// Validate theme value
+	if (theme !== 'light' && theme !== 'dark') {
+		return error(400, 'Invalid theme');
+	}
+
+	// Set cookie with 1-year expiration
+	cookies.set('theme', theme, {
+		path: '/',
+		maxAge: 60 * 60 * 24 * 365, // 1 year
+		sameSite: 'lax',
+	});
+
+	return json({ theme });
+};


### PR DESCRIPTION
## Add theme toggle component with cookie persistence

Steps:
- Create src/lib directory structure if not exists
- Create theme state file (src/lib/theme.svelte.ts) with  for theme
- Create ThemeToggle.svelte component using daisyUI toggle/swap
- Read theme from cookie in hooks.server.ts or +layout.server.ts
- Set data-theme on html element in app.html with SSR-safe approach
- Update cookie on toggle via form action or fetch
- Import and add ThemeToggle to the layout

---
*Automated by Ralph Loop (parallel mode)*