### PR TITLE
ac-003: Add theme toggle component with cookie persistence

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,7 +3,9 @@
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		interface Locals {
+			theme: 'light' | 'dark';
+		}
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}

--- a/src/app.html
+++ b/src/app.html
@@ -7,5 +7,13 @@
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>
+		<script>
+			// Prevent flash of unstyled content by applying theme before rendering
+			const theme =
+				document.documentElement.getAttribute('data-theme') ||
+				localStorage.getItem('theme') ||
+				'light';
+			document.documentElement.setAttribute('data-theme', theme);
+		</script>
 	</body>
 </html>

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,19 @@
+import { getCookieTheme } from '$lib/theme.svelte';
+import type { Handle } from '@sveltejs/kit';
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const cookieString = event.request.headers.get('cookie') ?? undefined;
+	const theme = getCookieTheme(cookieString);
+
+	// Make theme available to load functions
+	event.locals.theme = theme;
+
+	const response = await resolve(event, {
+		transformPageChunk: ({ html }) => {
+			// Add data-theme attribute to html element for SSR-safe theme
+			return html.replace('<html', `<html data-theme="${theme}"`);
+		},
+	});
+
+	return response;
+};

--- a/src/lib/ThemeToggle.svelte
+++ b/src/lib/ThemeToggle.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import { theme, type Theme, setThemeCookie } from './theme.svelte';
+
+	interface Props {
+		currentTheme?: Theme;
+	}
+
+	let { currentTheme = 'light' }: Props = $props();
+
+	let isTogglingTheme = $state(false);
+
+	async function handleToggle() {
+		if (isTogglingTheme) return;
+		isTogglingTheme = true;
+
+		try {
+			const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+			currentTheme = newTheme;
+			theme.setTheme(newTheme);
+
+			// Update theme attribute on HTML element
+			if (typeof document !== 'undefined') {
+				document.documentElement.setAttribute('data-theme', newTheme);
+			}
+
+			// Set cookie via fetch
+			await fetch('/api/theme', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ theme: newTheme }),
+			});
+		} finally {
+			isTogglingTheme = false;
+		}
+	}
+</script>
+
+<label class="swap swap-rotate">
+	<!-- this hidden checkbox controls the state -->
+	<input
+		type="checkbox"
+		checked={currentTheme === 'dark'}
+		onchange={handleToggle}
+		disabled={isTogglingTheme}
+	/>
+
+	<!-- sun icon -->
+	<svg
+		class="swap-off h-10 w-10 fill-current"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+	>
+		<path
+			d="M5.64,4.59L6.3,3.93A8,8,0,0,1,21.07,18.7l-.66.66A9.92,9.92,0,0,0,5.64,4.59ZM5,12a7,7,0,0,0,10.7,5.84l-.66-.66A5.5,5.5,0,0,1,6.66,6.66l.66.66A7,7,0,0,0,5,12Z"
+		/>
+	</svg>
+
+	<!-- moon icon -->
+	<svg
+		class="swap-on h-10 w-10 fill-current"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+	>
+		<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+	</svg>
+</label>
+
+<style>
+	:global(html) {
+		transition: background-color 0.3s ease, color 0.3s ease;
+	}
+
+	label {
+		display: inline-flex;
+		align-items: center;
+		cursor: pointer;
+	}
+</style>

--- a/src/lib/theme.svelte.ts
+++ b/src/lib/theme.svelte.ts
@@ -1,0 +1,38 @@
+import { writable } from 'svelte/store';
+
+export type Theme = 'light' | 'dark';
+
+const THEME_COOKIE_NAME = 'theme';
+const THEME_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+function createThemeStore() {
+	const { subscribe, set } = writable<Theme>('light');
+
+	return {
+		subscribe,
+		setTheme: (theme: Theme) => {
+			set(theme);
+		},
+		toggleTheme: (currentTheme: Theme) => {
+			const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+			set(newTheme);
+			return newTheme;
+		},
+	};
+}
+
+export const theme = createThemeStore();
+
+export function getCookieTheme(cookieString: string | undefined): Theme {
+	if (!cookieString) return 'light';
+
+	const themeMatch = cookieString.match(new RegExp(`(^|;)\\s*${THEME_COOKIE_NAME}=([^;]+)`));
+	const value = themeMatch?.[2];
+
+	return (value === 'dark' || value === 'light') ? value : 'light';
+}
+
+export function setThemeCookie(theme: Theme, cookieHeader: string = ''): string {
+	const cookieValue = `${THEME_COOKIE_NAME}=${theme}; Path=/; Max-Age=${THEME_COOKIE_MAX_AGE}; SameSite=Lax`;
+	return cookieValue;
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,7 @@
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ locals }) => {
+	return {
+		theme: locals.theme,
+	};
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,9 +1,23 @@
 <script lang="ts">
 	import './layout.css';
 	import favicon from '$lib/assets/favicon.svg';
+	import ThemeToggle from '$lib/ThemeToggle.svelte';
 
-	let { children } = $props();
+	interface LayoutData {
+		theme: 'light' | 'dark';
+	}
+
+	let { children, data }: { children: any; data: LayoutData } = $props();
 </script>
 
 <svelte:head><link rel="icon" href={favicon} /></svelte:head>
-{@render children()}
+
+<div class="min-h-screen" data-theme={data.theme}>
+	<header class="flex items-center justify-between bg-base-200 p-4">
+		<h1 class="text-2xl font-bold">My App</h1>
+		<ThemeToggle currentTheme={data.theme} />
+	</header>
+	<main>
+		{@render children()}
+	</main>
+</div>

--- a/src/routes/api/theme/+server.ts
+++ b/src/routes/api/theme/+server.ts
@@ -1,0 +1,22 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
+import { setThemeCookie } from '$lib/theme.svelte';
+
+export const POST: RequestHandler = async ({ request }) => {
+	const { theme } = await request.json();
+
+	if (!['light', 'dark'].includes(theme)) {
+		return json({ error: 'Invalid theme' }, { status: 400 });
+	}
+
+	const cookieHeader = setThemeCookie(theme);
+
+	return json(
+		{ success: true, theme },
+		{
+			headers: {
+				'Set-Cookie': cookieHeader,
+			},
+		}
+	);
+};


### PR DESCRIPTION
## Add theme toggle component with cookie persistence

Steps:
- Create src/lib directory structure if not exists
- Create theme state file (src/lib/theme.svelte.ts) with  for theme
- Create ThemeToggle.svelte component using daisyUI toggle/swap
- Read theme from cookie in hooks.server.ts or +layout.server.ts
- Set data-theme on html element in app.html with SSR-safe approach
- Update cookie on toggle via form action or fetch
- Import and add ThemeToggle to the layout

---
*Automated by Ralph Loop (parallel mode)*